### PR TITLE
fix: pin mimerl version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -22,7 +22,7 @@
 
 {deps, [
         {idna, "~>6.1.0"},
-        {mimerl, "~>1.1"},
+        {mimerl, "1.2.0"},
         {certifi, "~>2.10.0"},
         {metrics, "~>1.0.0"},
         {parse_trans, "3.4.1"},


### PR DESCRIPTION
`~>1.1` matches versions >= 1.1.0 and < 2.0.0.

`mimerl` 1.3.0 was released today

https://github.com/benoitc/mimerl/issues/4
